### PR TITLE
Use unknown.png image for 'undentified' tags

### DIFF
--- a/src/components/Video/ObservedAnimals.vue
+++ b/src/components/Video/ObservedAnimals.vue
@@ -83,7 +83,7 @@ export default {
       } else if (animal == 'bird/kiwi') {
         image = 'kiwi.png';
       } else if (animal == 'unidentified') {
-        image = 'none.png';
+        image = 'unknown.png';
       } else {
         image = animal + '.png';
       }


### PR DESCRIPTION
Was using none.png for both unidentified and false positives.