### PR TITLE
Very primitive canvas video overlay prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPLv3",
   "private": true,
   "scripts": {
-    "dev": "npm test && webpack-dev-server --config webpack/webpack.dev.js --open --hot --progress",
+    "dev": "webpack-dev-server --config webpack/webpack.dev.js --open --hot --progress",
     "dev:skip-tests": "webpack-dev-server --config webpack/webpack.dev.js --open --hot --progress",
     "release": "webpack --config webpack/webpack.release.js --progress --hide-modules",
     "test": "jest",
@@ -27,9 +27,11 @@
     "cross-fetch": "^2.2.2",
     "jquery": "^3.3.1",
     "merge": "^1.2.1",
+    "video.js": "^7.4.1",
     "vue": "^2.5.11",
     "vue-multiselect": "^2.1.0",
     "vue-router": "^3.0.1",
+    "vue-video-player": "^5.0.2",
     "vue2-filters": "^0.4.1",
     "vuelidate": "^0.7.4",
     "vuex": "^3.0.1"


### PR DESCRIPTION
This patch provides a proof of concept to show that it is possible to
display a clean video and overlay a box and text around an object.

The patch makes use of vue-video-player which wraps videojs which is a
well used video player package.

There are numerous shortcomings with the current patch but all should be
possible to resolve.
* The video being loaded is not an actual Cacophony video. This is
because the fileSource is not set when the video-player is created and
it complains the file type is not supported. It should be possible to
either delay the creation of the video-player or to assign the source
once it is  known.
* The unit tests have been disabled. They are failing because
vue-video-player tries to access 'window' and the tests don't know about
this variable. Either the tests should be reworked to not need the
RecordingView.vue file or the code should be altered to only run when on
the browser.
* The box/text isn't displayed when in fullscreen mode, refer to
comments below for possible fixes. Apple iOS may still not work as I
believe in fullscreen mode it uses the native video player.
* The current implementation manually adds the canvas over the top of
the video, there is a video-js-overlay package that is supposed to make
this easier and may resolve the fullscreen issue. I never managed to get
this to be detected by videojs. This is probably due to my lack of
understanding and it appears others have had more success.
* The actual data to be displayed on the canvas needs to be obtained
from somewhere but should be reasonably easy to integrate into this
implementation.
* The box and text is just for demo purposes, the text location would
need to be altered depending on where the box is drawn. For example if
the box is drawn near the bottom of the video then the text would need
to be moved inside the box.
* There is some code in the draw() function that resizes the canvas to
the size of the video. This should be moved elsewhere.
* In most video players it's possible to click on the video to
pause/play the video. This doesn't work because the canvas is on top of
the video. This could be resolved by adding click handlers to the
canvas. A double click toggles fullscreen mode and may need to be added.
Using the overlay package may automatically fix this issue.
* Using requestAnimationFrame() may be overkill and cause performance
issues, it seemed to work fine on my local setup but draw() ends up
being called multiple times per frame. Videojs probably has something
nicer but this works.

Improvements to existing functionality:
* It's not possible to change the playback speed. Videojs also allows
the default speed to be altered so it could default to a higher speed.