### PR TITLE
Will only hide metadata that is null

### DIFF
--- a/src/components/Video/VideoProperties.vue
+++ b/src/components/Video/VideoProperties.vue
@@ -21,7 +21,7 @@
               </p>
             </div>
           </div>
-          <p v-else-if="recording[prop.key]" >
+          <p v-else-if="recording[prop.key] != null" >
             <strong>{{ prop.title }}:</strong> {{ recording[prop.key] }}
           </p>
         </div>


### PR DESCRIPTION
When values like `airplaneModeOn` in the metadata was false they would not be shown. This should fix that.