### PR TITLE
Fix errors in query recordings mounted handler

### DIFF
--- a/src/components/QueryRecordings/QueryRecordings.vue
+++ b/src/components/QueryRecordings/QueryRecordings.vue
@@ -117,14 +117,14 @@ export default {
     }
   },
   mounted: function () {
-    if (this.$route.query) {
-      const query = this.$route.query;
-      this.devices = [JSON.parse(query.deviceId)];
-      this.recordingType = JSON.parse(query.recordingType);
-      this.fromDate = this.parseDate(new Date(query.fromDate));
-      this.toDate = this.parseDate(new Date(query.toDate));
-      this.buildQuery();
+    const query = this.$route.query;
+    if (query && Object.keys(query).length > 0) {
+      this.devices = (query.deviceId ? [JSON.parse(query.deviceId)] : []);
+      this.recordingType = (query.recordingType ? JSON.parse(query.recordingType) : 'both');
+      this.fromDate = (query.fromDate ? this.parseDate(new Date(query.fromDate)) : '');
+      this.toDate = (query.toDate ? this.parseDate(new Date(query.toDate)) : '');
     }
+    this.buildQuery();
   },
   methods: {
     parseDate (date) {


### PR DESCRIPTION
The guard for the query in the `mounted` handler was not complete
meaning there were errors reported every time the page loaded.

The empty object is now checked for correctly and there specific
guards for each query field in case any field is missing.

Also changed behaviour so that a query is always automatically
performed on page load as this has been requested before.