### PR TITLE
Refactored fetch API to return an object rather than the response body only fix #14

### DIFF
--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -8,6 +8,12 @@ const defaults = {
   headers: {}
 };
 
+/**
+ * Returns a promise that when resolved, returns an object with a result, success boolean, and status code.
+ * The result field is the JSON blob from the response body.
+ * These fields can easily be resolved using object destructuring to directly assign the required information.
+ * @returns {Promise<{result: any, success: boolean, status: number}>}
+ */
 export async function fetch() {
 
   const args = [].slice.call(arguments, 0);
@@ -23,15 +29,16 @@ export async function fetch() {
   };
 
   const response = await crossFetch.apply(this, args);
+  const status = response.status;
 
-  if(requiresAuth && response.status === 401) { // TODO: The API returns a 422 for an invalid JWT, is that an API bug or do we handle the fairly broad 422 as well? https://tree.taiga.io/project/the-cacophony-project/us/361
+  if(requiresAuth && status === 401) {
     store.dispatch('User/LOGOUT');
     router.push('login');
   }
 
   const result = await response.json();
-  handleMessages(result, response.status);
-  return result;
+  handleMessages(result, status);
+  return {result, status, success: response.ok};
 }
 
 function handleMessages(result, status) {

--- a/src/api/fetch.test.js
+++ b/src/api/fetch.test.js
@@ -58,7 +58,7 @@ test('fetch(url, paramsObject) handles response with general errors', async () =
     json: () => Promise.resolve(testResultObject)
   });
 
-  const result = await fetch('', {});
+  const {result} = await fetch('', {});
 
   expect(store.dispatch).toHaveBeenCalledTimes(2);
   expect(store.dispatch).toHaveBeenCalledWith('Messaging/ERROR', testResultObject.errors.someErrorKey.msg);
@@ -84,7 +84,7 @@ test('fetch(url, paramsObject) handles response with authentication error', asyn
     json: () => Promise.resolve(testResultObject)
   });
 
-  const result = await fetch('', {});
+  const {result} = await fetch('', {});
 
   expect(store.dispatch).toHaveBeenCalledTimes(2);
   expect(store.dispatch).toHaveBeenCalledWith('User/LOGOUT');
@@ -106,7 +106,7 @@ test('fetch(url, paramsObject) handles response with "success" result', async ()
     }
   });
 
-  const result = await fetch('', {});
+  const {result} = await fetch('', {});
 
   expect(store.dispatch).toHaveBeenCalledTimes(1);
   expect(store.dispatch).toHaveBeenCalledWith('Messaging/SUCCESS', testResultObject.messages[0]);

--- a/src/components/HomeGroupItem.vue
+++ b/src/components/HomeGroupItem.vue
@@ -65,12 +65,12 @@ export default {
     };
 
     // Get all data (first 1000 rows)
-    let allData = await api.query(params);
+    let {result: allData} = await api.query(params);
     // Check whether all data was fetched
     // if not, run again with increased limit to get all rows
     if (allData.count > limit) {
       params.limit = allData.count;
-      allData = await api.query(params);
+      ({result: allData} = await api.query(params));
     }
     this.count =  allData.count;
   },

--- a/src/components/Video/RecordingProperties.vue
+++ b/src/components/Video/RecordingProperties.vue
@@ -173,14 +173,14 @@ export default {
   },
   methods: {
     async updateComment() {
-      const result = await api.recording.comment(this.value, this.$route.params.id);
-      if(result.success) {
+      const {success} = await api.recording.comment(this.value, this.$route.params.id);
+      if(success) {
         this.showCommentAlert = true;
       }
     },
     async deleteRecording() {
-      const result = await api.recording.del(this.$route.params.id);
-      if(result.success) {
+      const {success} = await api.recording.del(this.$route.params.id);
+      if(success) {
         this.showDeleteAlert = true;
         this.$emit('nextOrPreviousRecording');
       }

--- a/src/stores/modules/Devices.store.js
+++ b/src/stores/modules/Devices.store.js
@@ -9,7 +9,7 @@ const state = {
 const getters = {};
 
 async function _getDevice(devicename, commit) {
-  const result = await api.device.getDevices();
+  const {result} = await api.device.getDevices();
   const device = result.devices.rows.find(device => device.devicename === devicename);
   commit('setCurrentDevice', device);
 }
@@ -17,7 +17,7 @@ async function _getDevice(devicename, commit) {
 const actions = {
   async GET_DEVICES({commit}) {
     commit('fetching');
-    const result = await api.device.getDevices();
+    const {result} = await api.device.getDevices();
     commit('receiveDevices', result.devices.rows);
     commit('fetched');
   },

--- a/src/stores/modules/Devices.store.test.js
+++ b/src/stores/modules/Devices.store.test.js
@@ -17,6 +17,7 @@ describe('Actions', () => {
           ]
       }
     },
+    testResponse = {result: testResult},
     commit = jest.fn(),
     state = {
       currentDevice: testResult.devices[0],
@@ -24,7 +25,7 @@ describe('Actions', () => {
     };
 
   beforeEach(() => {
-    api.getDevices.mockReturnValueOnce(testResult);
+    api.getDevices.mockReturnValueOnce(testResponse);
   });
 
   function _expectGetDevicesCalled(commit) {

--- a/src/stores/modules/Groups.store.js
+++ b/src/stores/modules/Groups.store.js
@@ -9,7 +9,7 @@ const state = {
 const getters = {};
 
 async function _getGroup(groupname, commit) {
-  const result = await api.groups.getGroups(groupname);
+  const {result} = await api.groups.getGroups(groupname);
   const group = result.groups[0];
   commit('setCurrentGroup', group);
   commit('receiveGroups', result.groups);
@@ -18,7 +18,7 @@ async function _getGroup(groupname, commit) {
 const actions = {
   async GET_GROUPS({commit}) {
     commit('fetching');
-    const result = await api.groups.getGroups();
+    const {result} = await api.groups.getGroups();
     commit('receiveGroups', result.groups);
     commit('fetched');
   },
@@ -31,8 +31,8 @@ const actions = {
 
   async ADD_GROUP({commit, state}, groupname) {
     commit('fetching');
-    var result = await api.groups.addNewGroup(groupname);
-    if(result.errors) {
+    const {success} = await api.groups.addNewGroup(groupname);
+    if(!success) {
       commit('fetched');
       throw "There were errors";
     }

--- a/src/stores/modules/Groups.store.test.js
+++ b/src/stores/modules/Groups.store.test.js
@@ -14,6 +14,7 @@ describe('Actions', () => {
         {groupname: 'b'}
       ]
     },
+    testResponse = {result: testResult},
     commit = jest.fn(),
     state = {
       currentGroup: testResult.groups[0],
@@ -21,7 +22,7 @@ describe('Actions', () => {
     };
 
   beforeEach(() => {
-    api.getGroups.mockReturnValueOnce(testResult);
+    api.getGroups.mockReturnValueOnce(testResponse);
   });
 
   function _expectGetGroupsCalled(commit) {
@@ -36,7 +37,7 @@ describe('Actions', () => {
   describe('GET_GROUPS', () => {
 
     beforeEach(async () => {
-      api.getGroups.mockReturnValueOnce(testResult);
+      api.getGroups.mockReturnValueOnce(testResponse);
       await GroupsStore.actions.GET_GROUPS({commit, state});
     });
 
@@ -77,7 +78,7 @@ describe('Actions', () => {
     const testString = "some string";
 
     beforeEach(async () => {
-      api.addNewGroup.mockReturnValueOnce({errors: "an error", success: false});
+      api.addNewGroup.mockReturnValueOnce({result: {errors: "an error"}, success: false});
     });
 
     test('calls api.groups.addNewGroup()', async () => {

--- a/src/stores/modules/User.store.js
+++ b/src/stores/modules/User.store.js
@@ -40,8 +40,8 @@ const actions = {
   async LOGIN({commit,}, payload) {
     commit('invalidateLogin');
 
-    const result = await api.user.login(payload.username, payload.password);
-    if(result.success) {
+    const {result, success} = await api.user.login(payload.username, payload.password);
+    if(success) {
       api.user.persistUser(result.userData.username, result.token, result.userData.email, result.userData.globalPermission);
       commit('receiveLogin', result);
     }
@@ -52,17 +52,17 @@ const actions = {
   },
   async REGISTER({commit}, payload) {
 
-    const result = await api.user.register(payload.username, payload.password, payload.email);
+    const {result, success} = await api.user.register(payload.username, payload.password, payload.email);
 
 
-    if(result.success) {
+    if(success) {
       api.user.persistUser(result.userData.username, result.token, result.userData.email, result.userData.globalPermission);
       commit('receiveLogin', result);
     }
   },
   async UPDATE ({ commit }, payload) {
-    const result = await api.user.updateFields(payload);
-    if (result.success) {
+    const {result, success} = await api.user.updateFields(payload);
+    if (success) {
       api.user.persistFields(payload);
       commit('updateFields', payload);
       return true;

--- a/src/stores/modules/Video.store.js
+++ b/src/stores/modules/Video.store.js
@@ -41,13 +41,13 @@ const getters = {
 };
 
 const getRecording = async function(commit, recordingId) {
-  const recording = await api.recording.id(recordingId);
+  const {result: recording} = await api.recording.id(recordingId);
   commit('receiveRecording', recording);
   return recording.success;
 };
 
 const getTracks = async function(commit, recordingId) {
-  const tracks = await api.recording.tracks(recordingId);
+  const {result: tracks} = await api.recording.tracks(recordingId);
   commit('receiveTracks', tracks);
   return tracks.success;
 };
@@ -55,8 +55,8 @@ const getTracks = async function(commit, recordingId) {
 const actions = {
 
   async QUERY_RECORDING(undefined, {params, direction, skipMessage}) {
-    const result = await api.recording.query(params);
-    if (!result.rows || result.rows.length == 0) {
+    const {result, success} = await api.recording.query(params);
+    if (!success || !result.rows || result.rows.length == 0) {
       if (!skipMessage) {
         store.dispatch('Messaging/WARN', `No ${direction} recording for this device.`);
       }

--- a/src/views/AnalysisView.vue
+++ b/src/views/AnalysisView.vue
@@ -173,12 +173,12 @@ export default {
       };
 
       // Get all data (first 1000 rows)
-      let allData = await api.query(params);
+      let {result: allData} = await api.query(params);
       // Check whether all data was fetched
       // if not, run again with increased limit to get all rows
       if (allData.count > limit) {
         params.limit = allData.count;
-        allData = await api.query(params);
+        ({result: allData} = await api.query(params));
       }
       // Count the number of recordings for each device
       this.devices.map((device) => this.deviceCount[device.id] = 0);

--- a/src/views/RecordingsView.vue
+++ b/src/views/RecordingsView.vue
@@ -270,7 +270,7 @@ export default {
 
       // Call API and process results
       this.queryPending = true;
-      const response = await api.recording.query(this.serialiseQuery(this.query, true));
+      const {result, success} = await api.recording.query(this.serialiseQuery(this.query, true));
       this.queryPending = false;
 
       // Remove previous values *again* since it's possible for the query to have been called twice
@@ -278,19 +278,19 @@ export default {
       this.recordings = [];
       this.tableItems = [];
 
-      if (!response.success) {
-        response.messages && response.messages.forEach(message => {
+      if (!success) {
+        result.messages && result.messages.forEach(message => {
           this.$store.dispatch('Messaging/WARN', message);
         });
       } else {
-        this.recordings = response.rows;
-        this.count = response.count;
-        if (response.count > 0) {
-          this.countMessage = `${response.count} matches found (total)`;
-        } else if (response.count === 0) {
+        this.recordings = result.rows;
+        this.count = result.count;
+        if (result.count > 0) {
+          this.countMessage = `${result.count} matches found (total)`;
+        } else if (result.count === 0) {
           this.countMessage = 'No matches';
         }
-        this.tableItems = response.rows.map((row) => ({
+        this.tableItems = result.rows.map((row) => ({
           id: row.id,
           type: row.type,
           devicename: row.Device.devicename,


### PR DESCRIPTION
Fixes #14

Can use object destructuring to have little clutter from the code and allows easy extension of the fetch API in the future if we need to return more information from the response