### PR TITLE
Workaround for tooltip positioning issues

### DIFF
--- a/src/components/Audio/TagList.vue
+++ b/src/components/Audio/TagList.vue
@@ -22,7 +22,7 @@
         slot="replayButton"
         slot-scope="row">
         <font-awesome-icon
-          v-b-popover.hover.bottom="'Replay'"
+          v-b-tooltip="'Replay'"
           :icon="['fa', 'play']"
           size="2x"
           style="cursor: pointer;"
@@ -33,7 +33,7 @@
         slot="deleteButton"
         slot-scope="row">
         <font-awesome-icon
-          v-b-popover.hover.bottom="'Delete tag'"
+          v-b-tooltip="'Delete tag'"
           icon="trash"
           size="2x"
           style="cursor: pointer;"

--- a/src/components/Help.vue
+++ b/src/components/Help.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    v-b-popover.hover="helpTip"
+    v-b-tooltip="helpTip"
     class="float-right help">?</span>
 </template>
 

--- a/src/components/Video/ObservedAnimals.vue
+++ b/src/components/Video/ObservedAnimals.vue
@@ -37,7 +37,7 @@
           slot="deleteButton"
           slot-scope="row">
           <font-awesome-icon
-            v-b-popover.hover.bottom="'Delete tag'"
+            v-b-tooltip.left="'Delete tag'"
             icon="trash"
             size="2x"
             style="cursor: pointer;"
@@ -47,7 +47,7 @@
           slot="confirmButton"
           slot-scope="row">
           <font-awesome-icon
-            v-b-popover.hover.bottom="'Confirm the automatic tag'"
+            v-b-tooltip.left="'Confirm the automatic tag'"
             v-if="row.item.tag.automatic && row.item.tag.animal !== 'unidentified'"
             icon="check-circle"
             size="2x"

--- a/src/components/Video/PrevNext.vue
+++ b/src/components/Video/PrevNext.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="img-buttons">
     <span
-      title="Previous for device, skipping bird &amp; false-positives"
+      v-b-tooltip.bottomlef
+      t="'Previous for device, skipping bird &amp; false-positives'"
       @click="gotoNextRecording('previous', 'tagged', ['interesting'])">
       <font-awesome-icon
         icon="asterisk"
@@ -13,7 +14,7 @@
         icon="angle-double-left" />
     </span>
     <span
-      title="Previous for device, not manually tagged"
+      v-b-tooltip.bottomleft="'Previous for device, not manually tagged'"
       @click="gotoNextRecording('previous', 'no-human')">
       <font-awesome-icon
         icon="question"
@@ -25,21 +26,21 @@
         icon="angle-left" />
     </span>
     <span
-      title="Previous for device"
+      v-b-tooltip.bottomleft="'Previous for device'"
       @click="gotoNextRecording('previous', 'any')">
       <font-awesome-icon
         icon="angle-left"
         class="fa-3x" />
     </span>
     <span
-      title="Next for device"
+      v-b-tooltip.bottomleft="'Next for device'"
       @click="gotoNextRecording('next', 'any')">
       <font-awesome-icon
         icon="angle-right"
         class="fa-3x" />
     </span>
     <span
-      title="Next for device, not manually tagged"
+      v-b-tooltip.bottomleft="'Next for device, not manually tagged'"
       @click="gotoNextRecording('next', 'no-human')">
       <font-awesome-icon
         class="fa-3x"
@@ -51,7 +52,7 @@
         value="?" />
     </span>
     <span
-      title="Next for device, skipping birds &amp; false-positives"
+      v-b-tooltip.bottomleft="'Next for device, skipping birds &amp; false-positives'"
       @click="gotoNextRecording('next', 'tagged', ['interesting'])">
       <font-awesome-icon
         class="fa-3x"

--- a/src/components/Video/TrackTags.vue
+++ b/src/components/Video/TrackTags.vue
@@ -22,11 +22,19 @@
           v-if="row.item.User"
           v-html="row.item.User.username"/>
       </template>
+      <!-- Be careful about changing the tooltips to use a placement
+           other than "left" here. This can cause the tooltips to be
+           positioned badly, causing flickering and leads to other
+           problems:
+
+           - https://github.com/TheCacophonyProject/cacophony-browse/issues/180
+           - ttps://github.com/TheCacophonyProject/cacophony-browse/issues/185
+        -->
       <template
         slot="deleteButton"
         slot-scope="row">
         <font-awesome-icon
-          v-b-popover.hover.bottom="'Delete tag'"
+          v-b-tooltip.left="'Delete tag'"
           v-if="!row.item.automatic"
           icon="trash"
           style="cursor: pointer;"
@@ -36,15 +44,8 @@
       <template
         slot="confirmButton"
         slot-scope="row">
-
-        <!-- using .top here to workaround a bug that caused the
-        popover to flicker otherwise - especaily on Chrome. Even
-        weirder, the popover still appears at the bottom.
-
-        See https://github.com/TheCacophonyProject/cacophony-browse/issues/180
-        -->
         <font-awesome-icon
-          v-b-popover.hover.top="'Confirm the automatic tag'"
+          v-b-tooltip.left="'Confirm the automatic tag'"
           v-if="row.item.automatic"
           icon="check-circle"
           style="cursor: pointer;"


### PR DESCRIPTION
- make track tag tooltips display on the right to avoid flickering and
- inaccessible buttons (fixes #185)
- switch from v-b-popover to v-b-tooltip throughout as these are more
  appropriate and have better contrast
- use v-b-tooltip instead of titles for prev/next recording buttons
  (for consistency)