### PR TITLE
Fix "other..." tag modal only working for first recording 

### DIFF
--- a/src/components/Audio/TagList.vue
+++ b/src/components/Audio/TagList.vue
@@ -22,7 +22,7 @@
         slot="replayButton"
         slot-scope="row">
         <font-awesome-icon
-          v-b-tooltip="'Replay'"
+          v-b-tooltip.hover="'Replay'"
           :icon="['fa', 'play']"
           size="2x"
           style="cursor: pointer;"
@@ -33,7 +33,7 @@
         slot="deleteButton"
         slot-scope="row">
         <font-awesome-icon
-          v-b-tooltip="'Delete tag'"
+          v-b-tooltip.hover="'Delete tag'"
           icon="trash"
           size="2x"
           style="cursor: pointer;"

--- a/src/components/Help.vue
+++ b/src/components/Help.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    v-b-tooltip="helpTip"
+    v-b-tooltip.hover="helpTip"
     class="float-right help">?</span>
 </template>
 

--- a/src/components/Video/AddCustomTrackTag.vue
+++ b/src/components/Video/AddCustomTrackTag.vue
@@ -1,6 +1,6 @@
 <template>
   <b-modal
-    :id="refTag"
+    id="custom-track-tag"
     title="Add track tag"
     @ok="quickTag">
     <b-form>
@@ -11,8 +11,8 @@
           v-model="whatTag"
           :options="whatOptions">
           <template slot="first">
-            <option 
-              :value="null" 
+            <option
+              :value="null"
               disabled>Choose a tag..
             </option>
           </template>
@@ -40,12 +40,6 @@ import DefaultLabels from '../../const.js';
 
 export default {
   name: 'AddCustomTrackTag',
-  props: {
-    refTag: {
-      type: String,
-      required: true,
-    }
-  },
   data () {
     return {
       whatTag: "cat",

--- a/src/components/Video/ObservedAnimals.vue
+++ b/src/components/Video/ObservedAnimals.vue
@@ -37,7 +37,7 @@
           slot="deleteButton"
           slot-scope="row">
           <font-awesome-icon
-            v-b-tooltip.left="'Delete tag'"
+            v-b-tooltip.hover.left="'Delete tag'"
             icon="trash"
             size="2x"
             style="cursor: pointer;"
@@ -47,7 +47,7 @@
           slot="confirmButton"
           slot-scope="row">
           <font-awesome-icon
-            v-b-tooltip.left="'Confirm the automatic tag'"
+            v-b-tooltip.hover.left="'Confirm the automatic tag'"
             v-if="row.item.tag.automatic && row.item.tag.animal !== 'unidentified'"
             icon="check-circle"
             size="2x"

--- a/src/components/Video/PrevNext.vue
+++ b/src/components/Video/PrevNext.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="img-buttons">
     <span
-      v-b-tooltip.bottomleft="'Previous for device, skipping bird &amp; false-positives'"
+      v-b-tooltip.hover.bottomleft="'Previous for device, skipping bird &amp; false-positives'"
       @click="gotoNextRecording('previous', 'tagged', ['interesting'])">
       <font-awesome-icon
         icon="asterisk"
@@ -13,7 +13,7 @@
         icon="angle-double-left" />
     </span>
     <span
-      v-b-tooltip.bottomleft="'Previous for device, not manually tagged'"
+      v-b-tooltip.hover.bottomleft="'Previous for device, not manually tagged'"
       @click="gotoNextRecording('previous', 'no-human')">
       <font-awesome-icon
         icon="question"
@@ -25,21 +25,21 @@
         icon="angle-left" />
     </span>
     <span
-      v-b-tooltip.bottomleft="'Previous for device'"
+      v-b-tooltip.hover.bottomleft="'Previous for device'"
       @click="gotoNextRecording('previous', 'any')">
       <font-awesome-icon
         icon="angle-left"
         class="fa-3x" />
     </span>
     <span
-      v-b-tooltip.bottomleft="'Next for device'"
+      v-b-tooltip.hover.bottomleft="'Next for device'"
       @click="gotoNextRecording('next', 'any')">
       <font-awesome-icon
         icon="angle-right"
         class="fa-3x" />
     </span>
     <span
-      v-b-tooltip.bottomleft="'Next for device, not manually tagged'"
+      v-b-tooltip.hover.bottomleft="'Next for device, not manually tagged'"
       @click="gotoNextRecording('next', 'no-human')">
       <font-awesome-icon
         class="fa-3x"
@@ -51,7 +51,7 @@
         value="?" />
     </span>
     <span
-      v-b-tooltip.bottomleft="'Next for device, skipping birds &amp; false-positives'"
+      v-b-tooltip.hover.bottomleft="'Next for device, skipping birds &amp; false-positives'"
       @click="gotoNextRecording('next', 'tagged', ['interesting'])">
       <font-awesome-icon
         class="fa-3x"

--- a/src/components/Video/QuickTagTrack.vue
+++ b/src/components/Video/QuickTagTrack.vue
@@ -27,7 +27,7 @@
       <div class="tag-name">nothing</div>
     </div>
     <div
-      v-b-modal="addRef"
+      v-b-modal="'custom-track-tag'"
       class="tag-div">
       <img
         class="tag-button"
@@ -44,10 +44,6 @@ import DefaultLabels from '../../const.js';
 export default {
   name: 'QuickTagTrack',
   props: {
-    addRef: {
-      type: String,
-      required: true,
-    },
     tags: {
       type: Array,
       required: true

--- a/src/components/Video/Track.vue
+++ b/src/components/Video/Track.vue
@@ -47,13 +47,11 @@
         <span class="delta"> (&#916; {{ (track.data.end_s - track.data.start_s) | currency('', 1) }}s) </span>
       </p>
       <QuickTagTrack
-        :add-ref="makeAddRef()"
         :tags="track.TrackTags"
         @addTag="addTag($event)"/>
       <TrackData
         :track-data="track.data"/>
       <AddCustomTrackTag
-        :ref-tag="makeAddRef()"
         @addTag="addTag($event)"/>
       <TrackTags
         :items="track.TrackTags"
@@ -161,9 +159,6 @@ export default {
     headerClass() {
       return "selected-" + this.show;
     },
-    makeAddRef() {
-      return "add-custom-tag-" + this.track.id;
-    }
   },
 };
 </script>

--- a/src/components/Video/TrackTags.vue
+++ b/src/components/Video/TrackTags.vue
@@ -34,7 +34,7 @@
         slot="deleteButton"
         slot-scope="row">
         <font-awesome-icon
-          v-b-tooltip.left="'Delete tag'"
+          v-b-tooltip.hover.left="'Delete tag'"
           v-if="!row.item.automatic"
           icon="trash"
           style="cursor: pointer;"
@@ -45,7 +45,7 @@
         slot="confirmButton"
         slot-scope="row">
         <font-awesome-icon
-          v-b-tooltip.left="'Confirm the automatic tag'"
+          v-b-tooltip.hover.left="'Confirm the automatic tag'"
           v-if="row.item.automatic"
           icon="check-circle"
           style="cursor: pointer;"


### PR DESCRIPTION
Use a fixed id for the modal so that it continues to work when moving between recordings. Fixes #184.

Also: Apply "hover" to all tooltips. The default is "hover focus" and "focus" means the tooltip can stay up if a button or icon is pushed.
