### PR TITLE
Restore recording comment functionality

### DIFF
--- a/src/components/Video/Comment.vue
+++ b/src/components/Video/Comment.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <b-modal
+      id="update-comment"
+      title="Update Comment"
+      @ok="updateComment"
+      @show="reset"
+      @shown="setFocus">
+      <b-form-group label="Comment">
+        <b-input
+          ref="comment-input"
+          v-model="comment"/>
+      </b-form-group>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Comment",
+  props: {
+    initialComment: {
+      type: String,
+      default: ""
+    }
+  },
+  data() {
+    return {
+      comment: this.initialComment
+    };
+  },
+  methods: {
+    async updateComment() {
+      this.$emit("updateComment", this.comment);
+    },
+    reset() {
+      this.comment = this.initialComment;
+    },
+    setFocus() {
+      this.$refs["comment-input"].focus();
+    }
+  }
+};
+</script>
+
+<style scoped></style>

--- a/src/components/Video/RecordingControls.vue
+++ b/src/components/Video/RecordingControls.vue
@@ -1,16 +1,20 @@
 <template>
   <div>
+    <Comment
+      :initial-comment="comment"
+      @updateComment="updateComment($event)"/>
     <div class="video-tags">
       <b-row class="pt-2 pb-2">
-        <b-col cols="4">
+        <b-col
+          cols="6"
+          md="3">
           <b-button-group
-            class="btn-block">
+            class="btn-block pb-2">
             <b-dropdown
               text="Label"
               right
               variant="info"
               class="btn-block">
-
               <b-dropdown-item
                 v-b-tooltip.hover.left="'An animal is in a trap in this recording'"
                 @click="addTrappedTag">
@@ -38,7 +42,20 @@
           </b-button-group>
         </b-col>
 
-        <b-col cols="4">
+        <b-col
+          cols="6"
+          md="3">
+          <b-button
+            v-b-modal.update-comment
+            variant="info"
+            block>
+            Comment
+          </b-button>
+        </b-col>
+
+        <b-col
+          cols="6"
+          md="3">
           <b-button-group
             v-b-tooltip.hover.top="'Download the files for this recording'"
             class="btn-block">
@@ -62,7 +79,9 @@
           </b-button-group>
         </b-col>
 
-        <b-col cols="4">
+        <b-col
+          cols="6"
+          md="3">
           <b-button
             v-b-tooltip.hover.bottomleft="'Delete this recording'"
             :disabled="deleteDisabled"
@@ -108,13 +127,19 @@
 
 <script>
 import api from '../../api/index';
+import Comment from './Comment.vue';
 
 export default {
   name: 'RecordingControls',
+  components: {Comment},
   props: {
     items: {
       type: Array,
       required: true
+    },
+    comment: {
+      type: String,
+      default: "",
     },
     downloadRawUrl: {
       type: String,
@@ -135,8 +160,6 @@ export default {
       ],
       deleteDisabled: false,
     };
-  },
-  computed: {
   },
   watch: {
     items: function () {
@@ -171,6 +194,9 @@ export default {
       if(success) {
         this.$emit('nextOrPreviousRecording');
       }
+    },
+    updateComment(event) {
+      this.$emit("updateComment", event);
     }
   }
 };

--- a/src/components/Video/VideoRecording.vue
+++ b/src/components/Video/VideoRecording.vue
@@ -14,10 +14,12 @@
         @nextOrPreviousRecording="prevNext"/>
       <RecordingControls
         :items="tagItems"
+        :comment="recording.comment"
         :download-raw-url="videoRawUrl"
         :download-file-url="videoUrl"
         @deleteTag="deleteTag($event)"
         @addTag="addTag($event)"
+        @updateComment="updateComment($event)"
         @nextOrPreviousRecording="gotoNextRecording('either', 'any')"/>
     </b-col>
 
@@ -173,6 +175,10 @@ export default {
       if (track != this.selectedTrack) {
         this.selectedTrack = track;
       }
+    },
+    updateComment(comment) {
+      const recordingId = Number(this.$route.params.id);
+      this.$store.dispatch('Video/UPDATE_COMMENT', { comment, recordingId });
     },
     orderedTracks: function() {
       return this.tracks.slice().sort((a, b) => a.data.start_s - b.data.start_s );

--- a/src/stores/modules/Video.store.js
+++ b/src/stores/modules/Video.store.js
@@ -108,6 +108,13 @@ const actions = {
     commit('deleteTag', tag);
   },
 
+  async UPDATE_COMMENT({commit}, { comment, recordingId }) {
+    const { success } = await api.recording.comment(comment, recordingId);
+    if (success) {
+      commit('updateComment', comment);
+    }
+  },
+
   async ADD_TAG(commit, {tag, id}) {
     await api.tag.addTag(tag, id);
     store.dispatch('Video/GET_RECORDING', id);
@@ -131,6 +138,9 @@ const mutations = {
     state.recording = recording;
     state.downloadFileJWT = downloadFileJWT;
     state.downloadRawJWT = downloadRawJWT;
+  },
+  updateComment(state, comment) {
+    state.recording.comment = comment;
   },
   deleteTag(state, tagId) {
     state.recording.Tags = state.recording.Tags.filter(tag => tag.id != tagId);


### PR DESCRIPTION
A new Comment button has been added which pops up a modal which shows
the current comment and allows it to be updated. Comment updates are
pushed through the store (the previous implementation made a direct
API request).

Four buttons on a single row didn't render well on mobile so the
buttons now spread over two rows on smaller screens.