### PR TITLE
Fix video tracks not displaying at a certain size (tablet-ish)

### DIFF
--- a/src/components/Video/Track.vue
+++ b/src/components/Video/Track.vue
@@ -224,7 +224,7 @@ export default {
     color: gray;
   }*/
 
-  @include media-breakpoint-down(lg) {
+  @include media-breakpoint-down(md) {
 
     .accordion > .card:first-of-type,
     .accordion > .card:not(:first-of-type):not(:last-of-type) {


### PR DESCRIPTION
At a certain size only one track was visible and there was no way of navigating between tracks (arrows were hidden)