### PR TITLE
Fix bug where fields to update were being wrapped in a fields object

### DIFF
--- a/src/api/User.api.js
+++ b/src/api/User.api.js
@@ -45,7 +45,7 @@ function register(username, password, email) {
   });
 }
 function updateFields(fields) {
-  return CacophonyApi.patch("/api/v1/Users", { fields });
+  return CacophonyApi.patch("/api/v1/Users", fields);
 }
 
 async function token() {


### PR DESCRIPTION
Intended for CacophonyApi.patch to receive the exact object as passed into updateFields,
for example if updateFields given:
`{ email: "mail@jacksteel.co.nz" }`
It should pass that to PATCH body.
Instead, it was incorrectly wrapping it into a fields object, meaning the PATCH body looked like
`{ fields : { email: "mail@jacksteel.co.nz" } }`
Which isn't what it should be and isn't what the server expects, meaning PATCH requests were failing.

I've gone through and done more testing for any other endpoints that had any semantic changes and am pretty confident this is the only issue.