### PR TITLE
fixed bug with page not loading for some urls

### DIFF
--- a/src/components/QueryRecordings/QueryRecordings.vue
+++ b/src/components/QueryRecordings/QueryRecordings.vue
@@ -266,7 +266,7 @@ export default {
   mounted() {
     this.isAudio = this.recordingType === "audio";
     this.parseCurrentRoute();
-    this.lastQuery = JSON.parse(JSON.stringify(this.query));
+    this.saveLastQuery();
     this.$emit("submit", this.serialiseQuery(this.query, true));
   },
   updated() {
@@ -284,6 +284,9 @@ export default {
     }
   },
   methods: {
+    saveLastQuery() {
+      this.lastQuery = JSON.parse(JSON.stringify(this.query));
+    },
     updatePagination(perPage, page) {
       this.query.limit = perPage;
       const newOffset = Math.max(0, (page - 1) * perPage);
@@ -342,7 +345,7 @@ export default {
     },
     updateRouteQuery() {
       // Update the url query params string so that this search can be easily shared.
-      this.lastQuery = JSON.parse(JSON.stringify(this.query));
+      this.saveLastQuery();
       this.$router.push({
         path: this.path,
         query: this.serialiseQuery(this.query)

--- a/src/components/QueryRecordings/QueryRecordings.vue
+++ b/src/components/QueryRecordings/QueryRecordings.vue
@@ -266,7 +266,8 @@ export default {
   mounted() {
     this.isAudio = this.recordingType === "audio";
     this.parseCurrentRoute();
-    this.updateRouteQuery();
+    this.lastQuery = JSON.parse(JSON.stringify(this.query));
+    this.$emit("submit", this.serialiseQuery(this.query, true));
   },
   updated() {
     if (!this.loadedQuery) {


### PR DESCRIPTION
specifically when date time parameter of all was selected, if you releoaded the page it would get stuck on loading...

this occured because the route remained the same and we were only firing the submit event when the $route watch event fired.
while with a relative date, the seconds changed (since initial load) and hence $route changed and we get the event load recordings