### PR TITLE
Don't send deviceId to /needs-tag if it is null

### DIFF
--- a/src/api/Recording.api.ts
+++ b/src/api/Recording.api.ts
@@ -292,7 +292,7 @@ interface RecordingToTag {
 
 function needsTag(biasToDeviceId?: DeviceId): Promise<RecordingToTag> {
   let requestUri = `${apiPath}/needs-tag`;
-  if (biasToDeviceId !== undefined) {
+  if (biasToDeviceId != null) {
     requestUri += `?deviceId=${biasToDeviceId}`;
   }
   return CacophonyApi.get(requestUri);


### PR DESCRIPTION
It might be null or undefined - support both.