### PR TITLE
- Add tagger delete recording button for globalWrite users

### DIFF
--- a/src/components/Video/ThermalVideoPlayer.vue
+++ b/src/components/Video/ThermalVideoPlayer.vue
@@ -29,6 +29,7 @@
       @ended="showEndedOverlay"
       @canplay="canPlay"
       @ready="playerReady"
+      @error="videoError"
     />
     <transition name="fade">
       <div class="load-overlay" v-if="loading">
@@ -117,12 +118,7 @@ export default {
         width: "800px",
         playbackRates: [0.5, 1, 2, 4, 8],
         inactivityTimeout: 0,
-        sources: [
-          {
-            type: "video/mp4",
-            src: "blah blah"
-          }
-        ]
+        sources: []
       },
       vjsButtonWidth: 50, //button width + duration margin
       canvasWidth: 800,
@@ -161,7 +157,6 @@ export default {
   },
   mounted() {
     this.initOverlayCanvas();
-    this.setVideoUrl();
     window.addEventListener("resize", this.onResize);
   },
   beforeDestroy() {
@@ -219,10 +214,17 @@ export default {
       // first must make sure the width to be loaded is also correct.
       this.playerOptions.width = this.canvasWidth + "px";
       this.playerOptions.height = this.canvasHeight + "px";
-      this.$data.playerOptions.sources[0].src = this.videoUrl;
-      // if tracks is loaded then select the first track
-      if (this.currentTrack !== 0) {
-        this.$emit("trackSelected", 0);
+      if (this.videoUrl) {
+        this.$data.playerOptions.sources = [
+          {
+            type: "video/mp4",
+            src: this.videoUrl
+          }
+        ];
+        // if tracks is loaded then select the first track
+        if (this.currentTrack !== 0) {
+          this.$emit("trackSelected", 0);
+        }
       }
     },
     replay() {
@@ -243,6 +245,9 @@ export default {
       this.bindRateChange();
       this.selectTrack();
       this.playerIsReady = true;
+    },
+    videoError() {
+      this.requestNextVideo();
     },
     selectTrack() {
       this.lastDisplayedVideoTime = -1;

--- a/src/views/TaggingView.vue
+++ b/src/views/TaggingView.vue
@@ -32,6 +32,23 @@
             @request-next-recording="nextRecording"
             @ready-to-play="playerIsReady"
           />
+          <div class="actions">
+            <b-button
+              :disabled="!readyToTag || history.length === 0"
+              @click="undo"
+            >
+              Undo last action
+            </b-button>
+            <b-button @click="showMotionPaths = !showMotionPaths">
+              {{ showMotionPaths ? "Hide" : "Show" }} motion paths
+            </b-button>
+            <b-button
+              variant="danger"
+              @click="deleteVideo"
+              v-if="currentUser.globalPermission === 'write'"
+              >Delete recording</b-button
+            >
+          </div>
         </div>
       </div>
       <div class="controls">
@@ -75,14 +92,7 @@
         </div>
       </div>
     </div>
-    <div class="actions">
-      <b-button :disabled="!readyToTag || history.length === 0" @click="undo">
-        Undo last action
-      </b-button>
-      <b-button @click="showMotionPaths = !showMotionPaths">
-        {{ showMotionPaths ? "Hide" : "Show" }} motion paths
-      </b-button>
-    </div>
+
     <div>
       <h4 v-if="readyToTag || !loading">
         Tagging: Track {{ currentTrackIndex + 1 }},
@@ -168,6 +178,11 @@ export default Vue.extend({
       this.currentRecording = recording;
       this.tracks = tracks;
       this.currentTrackIndex = trackIndex;
+    },
+    async deleteVideo() {
+      this.readyToPlay = false;
+      await api.recording.del(this.currentRecording.RecordingId);
+      await this.nextRecording();
     },
     playerIsReady() {
       this.readyToPlay = true;
@@ -452,7 +467,7 @@ export default Vue.extend({
   background: orange;
 }
 .actions {
-  padding: 10px 0;
+  padding: 10px 10px 10px 0;
   display: flex;
   justify-content: space-between;
 }


### PR DESCRIPTION
- Change position of action buttons to have less white space
  in cases where there aren't many tracks
- Handle video player load errors by requesting the next
  video if loading fails.
- Don't load dummy recording src on load, this results in an error.