### PR TITLE
Try to set the video url on mount, rather than relying

### DIFF
--- a/src/components/Video/ThermalVideoPlayer.vue
+++ b/src/components/Video/ThermalVideoPlayer.vue
@@ -157,6 +157,7 @@ export default {
   },
   mounted() {
     this.initOverlayCanvas();
+    this.setVideoUrl();
     window.addEventListener("resize", this.onResize);
   },
   beforeDestroy() {

--- a/src/views/RecordingView.vue
+++ b/src/views/RecordingView.vue
@@ -86,8 +86,13 @@ export default {
         }
         return "";
       },
-      fileSource: state =>
-        `${config.api}/api/v1/signedUrl?jwt=${state.Video.downloadFileJWT}`,
+      fileSource: state => {
+        return (
+          (state.Video.downloadFileJWT &&
+            `${config.api}/api/v1/signedUrl?jwt=${state.Video.downloadFileJWT}`) ||
+          ""
+        );
+      },
       rawSource: state =>
         `${config.api}/api/v1/signedUrl?jwt=${state.Video.downloadRawJWT}`
     })


### PR DESCRIPTION
on watched variables changing to set the video initially.

(Previously the video player relied on a dummy src url being set to trigger a Vue watcher to initialise the url of the player, but this caused a video js error in the console, as the player couldn't load the dummy url - it's better to initialise those sorts of things inside the component mount hook)