### PR TITLE
Alert banner full width, added padding to text

### DIFF
--- a/src/components/GlobalMessaging.vue
+++ b/src/components/GlobalMessaging.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container">
-    <div v-for="(item, index) in getMessages()" :key="index" class="row">
+    <div v-for="(item, index) in getMessages()" :key="index">
       <b-alert
         v-if="displayLevels.includes(item.level)"
         :variant="item.level"
@@ -8,9 +8,7 @@
         dismissible
         @dismissed="acknowledgeMessages"
       >
-        <div
-          class="col-sm-11 offset-sm-1 col-md-7 offset-md-2 col-lg-4 offset-lg-4 box"
-        >
+        <div class="box">
           <icon-link :icon="['fas', 'exclamation-triangle']" :colour="'red'" />
           Oops! Something went wrong. <br />
           Message is: "{{ item.message }}"
@@ -51,11 +49,10 @@ export default {
 <style scoped>
 .container {
   position: fixed;
-  width: 100%;
+  min-width: 100%;
   z-index: 1000;
   left: 0;
   right: 0;
-  max-width: 100000px;
   padding: 0;
   box-shadow: black;
   transition: all 500ms ease-in;
@@ -69,6 +66,7 @@ export default {
 
 .alert {
   position: absolute;
+  padding-left: 5%;
   margin-bottom: 0;
   border-radius: 0;
   width: 100%;


### PR DESCRIPTION
- Alert banner stretches 100% width now (before it had a gap on the right)
- Removed 100000px attempt 
- Removed classes that were causing this conflict in styling
- Added small left padding to give error text a bit of breathing space - if you want it centred or something else feel free to let me know! 

![image](https://user-images.githubusercontent.com/11302742/92287761-d653c580-ef5e-11ea-8490-495a99c9bd23.png)
