### PR TITLE
Fix navbar message

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bootstrap": "^4.5.3",
     "bootstrap-vue": "^2.20.1",
     "chart.js": "^2.9.4",
-    "cptv-player-vue": "github:TheCacophonyProject/cptv-player-vue#v1.0.9",
+    "cptv-player-vue": "github:TheCacophonyProject/cptv-player-vue#v1.0.10",
     "cross-fetch": "^3.0.6",
     "csvtojson": "^2.0.10",
     "jquery": "^3.5.1",

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -12,7 +12,7 @@
       >
     </div>
     <div
-      v-if="config.env !== 'PRODUCTION' && showRevisionInfo"
+      v-if="config.environment !== 'PRODUCTION' && showRevisionInfo"
       class="git-revision-bar"
     >
       <a :href="revisionLink" target="_blank" :title="commitMessage">{{


### PR DESCRIPTION
Realised that top revision info banner wasn't checking the correct variable, and would have shown up on prod